### PR TITLE
Align room tile info in space hierarchy

### DIFF
--- a/res/css/structures/_SpaceHierarchy.scss
+++ b/res/css/structures/_SpaceHierarchy.scss
@@ -220,7 +220,7 @@ limitations under the License.
             line-height: $font-18px;
             color: $secondary-content;
             grid-row: 2;
-            grid-column: 1/3;
+            grid-column: 2/3;
             display: -webkit-box;
             -webkit-box-orient: vertical;
             -webkit-line-clamp: 2;


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/32841439/148766778-7aacecda-1dc9-441a-af62-4d5eed41c89b.png)

after:
![image](https://user-images.githubusercontent.com/32841439/148766887-3895d34a-cf8c-45bd-8dc3-deb9c53a1318.png)

Signed-off-by: ajbura ajbura@gmail.com